### PR TITLE
feat: Setup proper publishing workflow with automated releases

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -7,12 +7,6 @@ on:
         description: 'Version to test (optional - uses current version if empty)'
         required: false
         type: string
-  push:
-    branches: [ main ]
-    paths:
-      - 'pyproject.toml'
-      - 'src/ccnotify/**'
-      - '.github/workflows/test-publish.yml'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-08-04
+
+### 🐛 Fixed
+- **Improved pronunciation for TTS**: Now uses values from replacements.json for better TTS output
+- **Cleaner sound file names**: Removed TTS provider prefix from cached sound files
+- **Better curl/wget handling**: Improved notification handling for download commands
+
+## [0.1.11] - 2025-08-04
+
+### 🐛 Fixed
+- **Cleaner notifications**: Prevented code snippets from appearing in notification messages
+
+## [0.1.10] - 2025-08-04
+
+### ✨ Added
+- **Embedded Kokoro TTS**: Kokoro TTS now embedded directly in notify.py for standalone execution
+
+## [0.1.9] - 2025-08-03
+
+### ✨ Added
+- **Enhanced Kokoro configuration**: Improved voice configuration and project detection
+
+### 🐛 Fixed
+- **Project detection fallback**: Fixed detection when Claude doesn't send sessionId
+
+## [0.1.8] - 2025-08-03
+
+### 🐛 Fixed
+- **Test installer error**: Fixed script_exists attribute error in test_installer.py
+
+## [0.1.7] - 2025-08-03
+
+### ✨ Added
+- **Duplicate hooks fix script**: Added utility script to fix duplicate hooks for affected users
+- **Comprehensive testing infrastructure**: Added local testing capabilities
+
+### 🐛 Fixed
+- **Critical hook duplication bug**: Fixed issues with duplicate hook detection and prevention
+
+## [0.1.6] - 2025-08-03
+
+### 🐛 Fixed
+- **Update flow improvements**: Fixed version management and update flow issues
+- **Update fixes current version**: Update flow now fixes issues even when version is current
+
 ## [0.1.5] - 2025-08-03
 
 ### 🐛 Fixed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # CCNotify
 
+[![Latest Release](https://img.shields.io/github/v/release/Helmi/ccnotify)](https://github.com/Helmi/ccnotify/releases/latest)
+[![PyPI](https://img.shields.io/pypi/v/ccnotify)](https://pypi.org/project/ccnotify/)
+
 ## Voice Notification System for Claude Code
 
 - 🗣️ Have your favourite Voide tell you what's up in Claude Code
@@ -114,7 +117,7 @@ Customize how project names are pronounced by editing `~/.claude/ccnotify/replac
 
 ## Early Version Notice
 
-This is v0.1.12 - an early release focused on core functionality. Features may change based on feedback.
+This is an early release focused on core functionality. Features may change based on feedback.
 
 **Issues & Suggestions**: Please use [GitHub Issues](https://github.com/Helmi/ccnotify/issues) to report problems or suggest improvements.
 


### PR DESCRIPTION
## Summary

- Establishes comprehensive release workflow for automated PyPI publishing
- Converts TestPyPI publishing to manual-only triggering
- Updates documentation to use dynamic version badges

Closes #1

## Changes Made

### Workflow Updates
- **Modified `.github/workflows/test-publish.yml`**: Removed automatic triggers on push to main, keeping only manual workflow_dispatch
- **Verified `.github/workflows/publish-pypi.yml`**: Already correctly configured to trigger on GitHub release events

### Documentation Updates
- **README.md**: 
  - Removed hardcoded version "v0.1.12" from line 117
  - Added GitHub release badge and PyPI version badge at the top
- **CHANGELOG.md**: 
  - Added missing version entries for 0.1.6 through 0.1.12
  - Documented all recent changes based on commit history

## Test Plan

- [x] Verify test-publish.yml only has manual trigger
- [x] Confirm publish-pypi.yml triggers on release events
- [x] Check README badges render correctly
- [x] Validate CHANGELOG formatting
- [ ] Test manual TestPyPI workflow after merge
- [ ] Create a test pre-release to verify PyPI publishing

## Release Process (Post-Merge)

1. Manually trigger TestPyPI workflow to test package
2. Create GitHub release with appropriate tag
3. PyPI workflow will automatically publish on release creation
4. Version badges will auto-update to show latest release